### PR TITLE
fixed a viterbi decode bug

### DIFF
--- a/model.py
+++ b/model.py
@@ -154,7 +154,8 @@ class crf(nn.Module):
         # back-tracking
         best_path = [best_tag]
         for bptr_t in reversed(bptr):
-            best_path.append(bptr_t[best_tag])
+            best_tag = bptr_t[best_tag]
+            best_path.append(best_tag)
         best_path = reversed(best_path[:-1])
 
         return best_path


### PR DESCRIPTION
The value of best_tag is changing in every iteration, if we use bptr_t[best_tag] instead of recording the  value using `best_tag = bptr_t[best_tag]`, we can't use newest `best_tag` in the next iteration step. it is not right.